### PR TITLE
Test for a unique ID in MQTT topic name injected by ID env var

### DIFF
--- a/exercises/how_long_to_expose_film/exercise.js
+++ b/exercises/how_long_to_expose_film/exercise.js
@@ -12,6 +12,9 @@ var notifier = require('../../lib/notifier')
 var broadcaster = require('../../lib/broadcaster')
 var serveUi = require('../../lib/serve-ui')
 
+var topicId = 'unique-id-' + Math.round(Math.random() * 100000),
+    mqttTopicWithId = 'ciot/pinhole/' + topicId + '/light/value';
+
 // checks that the submission file actually exists
 exercise = filecheck(exercise)
 
@@ -20,6 +23,10 @@ exercise.addProcessor(serveUi)
 
 // this actually runs the solution
 exercise.addProcessor(function (mode, callback) {
+
+  // Inject ID into subsmission
+  process.env.ID = topicId;
+
   // includes the solution to run it
   proxyquire(path.join(process.cwd(), exercise.args[0]), {
     'mqtt': mqtt,
@@ -72,8 +79,8 @@ exercise.addVerifyProcessor(function (callback) {
     // client subscribes and publishes only after connecting
     expect(onConnect.calledBefore(subscribe0), 'client unexpectedly subscribed before connecting').to.be.true
 
-    // client subscribes to 'ciot/pinhole/light/value' topic
-    expect(subscribe0.args[0], 'client does not subscibe to correct topic').to.equal('ciot/pinhole/light/value')
+    // client subscribes to 'ciot/pinhole/<id>/light/value' topic
+    expect(subscribe0.args[0], 'client does not subscibe to correct topic').to.equal(mqttTopicWithId)
 
     expect(lightmeter.instances.length, 'expected 1 widget instance').to.equal(1);
 

--- a/exercises/how_long_to_expose_film/exercise.js
+++ b/exercises/how_long_to_expose_film/exercise.js
@@ -12,9 +12,6 @@ var notifier = require('../../lib/notifier')
 var broadcaster = require('../../lib/broadcaster')
 var serveUi = require('../../lib/serve-ui')
 
-var topicId = 'unique-id-' + Math.round(Math.random() * 100000),
-    mqttTopicWithId = 'ciot/pinhole/' + topicId + '/light/value';
-
 // checks that the submission file actually exists
 exercise = filecheck(exercise)
 
@@ -23,9 +20,6 @@ exercise.addProcessor(serveUi)
 
 // this actually runs the solution
 exercise.addProcessor(function (mode, callback) {
-
-  // Inject ID into subsmission
-  process.env.ID = topicId;
 
   // includes the solution to run it
   proxyquire(path.join(process.cwd(), exercise.args[0]), {
@@ -46,6 +40,11 @@ exercise.addProcessor(function (mode, callback) {
 // add a processor only for 'verify' calls
 exercise.addVerifyProcessor(function (callback) {
   try {
+
+    // expect that id is set in environment
+    expect(process.env.ID, 'No ID environment variable set. Did you set it with ID=<your-id>?').to.exist
+
+    var mqttTopicWithId = 'ciot/pinhole/' + process.env.ID + '/light/value';
 
     // mqtt client was connected
     expect(mqtt.connect, 'no mqtt connection').to.be.called;

--- a/exercises/how_long_to_expose_film/problem.md
+++ b/exercises/how_long_to_expose_film/problem.md
@@ -43,4 +43,4 @@ You can pass an array of objects to `addLightingCondition()`.
 
 The widget includes an array of default conditions, try `console.log(LightMeterWidget.defaults)`.
 
-Don't forget, you can run your program in the browser using `lightmeter --port 11686 program.js` and loading the URL in your browser.
+Don't forget, you can run your program in the browser using `ID=<your-id> lightmeter --port 11686 program.js` and loading the URL in your browser.

--- a/exercises/how_long_to_expose_film/solution/solution.js
+++ b/exercises/how_long_to_expose_film/solution/solution.js
@@ -1,6 +1,9 @@
 var mqtt = require('mqtt');
 var LightMeterWidget = require('lightmeter').Widget;
 
+var id = process.env.ID;
+var lightTopic = 'ciot/pinhole/' + id + '/light/value';
+
 var lightTopic = 'ciot/pinhole/light/value';
 
 var lightMeter = new LightMeterWidget();

--- a/exercises/let_there_be_light/exercise.js
+++ b/exercises/let_there_be_light/exercise.js
@@ -13,14 +13,8 @@ var broadcaster = require('../../lib/broadcaster')
 // checks that the submission file actually exists
 exercise = filecheck(exercise)
 
-var topicId = 'unique-id-' + Math.round(Math.random() * 100000),
-    mqttTopicWithId = 'ciot/pinhole/' + topicId + '/light/value';
-
 // this actually runs the solution
 exercise.addProcessor(function (mode, callback) {
-
-  // Inject ID into subsmission
-  process.env.ID = topicId;
 
   // includes the solution to run it
   proxyquire(path.join(process.cwd(), exercise.args[0]), {
@@ -41,6 +35,11 @@ exercise.addProcessor(function (mode, callback) {
 // add a processor only for 'verify' calls
 exercise.addVerifyProcessor(function (callback) {
   try {
+
+    // expect that id is set in environment
+    expect(process.env.ID, 'No ID environment variable set. Did you set it with ID=<your-id>?').to.exist
+
+    var mqttTopicWithId = 'ciot/pinhole/' + process.env.ID + '/light/value';
 
     // mqtt client was connected
     expect(mqtt.connect, 'no mqtt connection').to.be.called;

--- a/exercises/let_there_be_light/problem.md
+++ b/exercises/let_there_be_light/problem.md
@@ -17,7 +17,15 @@ __Write a program that measures and publishes photoresistor readings.__
 
 The ID in the MQTT topic should be unique to your light sensor otherwise you could overwrite others' values.
 
-Make sure you set an environment variable of ID=<yourname> when you run your program. You can read this id in your program using `process.env.ID`.
+Make sure you set an environment variable of ID=<yourname> when you run your program and when you verify:
+
+    ID=<your-id> smart-pinhole-workshop verify program.js
+
+And:
+
+    ID=<your-id> node program.js
+
+You can read this id in your program using `process.env.ID`.
 
 ## Schematic
 

--- a/exercises/let_there_be_light/problem.md
+++ b/exercises/let_there_be_light/problem.md
@@ -7,11 +7,17 @@ We will use our newly acquired `MQTT` & `johnny-five` skills.
 __Write a program that measures and publishes photoresistor readings.__
 
 * Use a photoresistor
-* Connect the photoresistor to **A0** 
+* Connect the photoresistor to **A0**
 * Ensure we get sensor readings every 250 ms
 * Readings should be scaled between 0 and 1
-* Publish photoresistor readings on the **ciot/pinhole/light/value** MQTT topic
+* Publish photoresistor readings on the **ciot/pinhole/<id>/light/value** MQTT topic
 * Ensure published readings are retained for guaranteed pick up
+
+## Unique ID for topic
+
+The ID in the MQTT topic should be unique to your light sensor otherwise you could overwrite others' values.
+
+Make sure you set an environment variable of ID=<yourname> when you run your program. You can read this id in your program using `process.env.ID`.
 
 ## Schematic
 

--- a/exercises/let_there_be_light/solution/solution.js
+++ b/exercises/let_there_be_light/solution/solution.js
@@ -5,7 +5,10 @@ var client = mqtt.connect({
   host: 'test.mosquitto.org',
   port: '1883'
 })
-var topic = 'ciot/pinhole/light/value'
+
+var id = process.env.ID;
+
+var topic = 'ciot/pinhole/' + id + '/light/value'
 
 var board = new five.Board()
 

--- a/exercises/put_it_all_together/problem.md
+++ b/exercises/put_it_all_together/problem.md
@@ -8,11 +8,11 @@ __Launch both apps to see the exposure time change with light levels.__
 
 In a new terminal window, run exercise 3. "Let there be light":
 
-    node 03_let_there_be_light
+    ID=<your-id> node 03_let_there_be_light
 
 Then, in this window run your program from the last exercise:
 
-    lightmeter --port 11686 program.js
+    ID=<your-id> lightmeter --port 11686 program.js
 
 Cover the sensor with your hand to see the value change in the web UI.
 

--- a/exercises/receive_light/exercise.js
+++ b/exercises/receive_light/exercise.js
@@ -14,11 +14,18 @@ var serveUi = require('../../lib/serve-ui')
 // checks that the submission file actually exists
 exercise = filecheck(exercise)
 
+var topicId = 'unique-id-' + Math.round(Math.random() * 100000),
+    mqttTopicWithId = 'ciot/pinhole/' + topicId + '/light/value';
+
 // Serve UI
 exercise.addProcessor(serveUi)
 
 // this actually runs the solution
 exercise.addProcessor(function (mode, callback) {
+
+  // Inject ID into subsmission
+  process.env.ID = topicId;
+
   // includes the solution to run it
   proxyquire(path.join(process.cwd(), exercise.args[0]), {
     'mqtt': mqtt,
@@ -71,8 +78,8 @@ exercise.addVerifyProcessor(function (callback) {
     // client subscribes and publishes only after connecting
     expect(onConnect.calledBefore(subscribe0), 'client unexpectedly subscribed before connecting').to.be.true
 
-    // client subscribes to 'ciot/pinhole/light/value' topic
-    expect(subscribe0.args[0], 'client does not subscibe to correct topic').to.equal('ciot/pinhole/light/value')
+    // client subscribes to 'ciot/pinhole/<id>/light/value' topic
+    expect(subscribe0.args[0], 'client does not subscibe to correct topic').to.equal(mqttTopicWithId)
 
     expect(lightmeter.instances.length, 'expected 1 widget instance').to.equal(1);
 

--- a/exercises/receive_light/exercise.js
+++ b/exercises/receive_light/exercise.js
@@ -14,17 +14,11 @@ var serveUi = require('../../lib/serve-ui')
 // checks that the submission file actually exists
 exercise = filecheck(exercise)
 
-var topicId = 'unique-id-' + Math.round(Math.random() * 100000),
-    mqttTopicWithId = 'ciot/pinhole/' + topicId + '/light/value';
-
 // Serve UI
 exercise.addProcessor(serveUi)
 
 // this actually runs the solution
 exercise.addProcessor(function (mode, callback) {
-
-  // Inject ID into subsmission
-  process.env.ID = topicId;
 
   // includes the solution to run it
   proxyquire(path.join(process.cwd(), exercise.args[0]), {
@@ -45,6 +39,11 @@ exercise.addProcessor(function (mode, callback) {
 // add a processor only for 'verify' calls
 exercise.addVerifyProcessor(function (callback) {
   try {
+
+    // expect that id is set in environment
+    expect(process.env.ID, 'No ID environment variable set. Did you set it with ID=<your-id>?').to.exist
+
+    var mqttTopicWithId = 'ciot/pinhole/' + process.env.ID + '/light/value';
 
     // mqtt client was connected
     expect(mqtt.connect, 'no mqtt connection').to.be.called;

--- a/exercises/receive_light/problem.md
+++ b/exercises/receive_light/problem.md
@@ -10,11 +10,17 @@ __Write some browser code that subscribes to our MQTT photoresistor readings and
 
 * Connect to the `test.mosquitto.org` MQTT broker
 * Use the WebSocket port (8080) and the 'ws' protocol
-* Subscribe to readings on the **ciot/pinhole/light/value** MQTT topic
+* Subscribe to readings on the **ciot/pinhole/<your-id>/light/value** MQTT topic
+
+## Unique ID for topic
+
+As before, you should set an ID in the MQTT topic that's unique to your light sensor. Make sure you use the same ID as before!
+
+Set an environment variable of ID=<yourname> when you run your program. You can read this id in your program using `process.env.ID`.
 
 ## Running the solution
 
-Use `lightmeter --port 11686 program.js` to start a local server that you can open in your browser. Your browser code will be injected into the application so you can view it.
+Use `ID=<your-id> lightmeter --port 11686 program.js` to start a local server that you can open in your browser. Your browser code will be injected into the application so you can view it.
 
 Reloading the page will load the latest version of your code.
 

--- a/exercises/receive_light/solution/solution.js
+++ b/exercises/receive_light/solution/solution.js
@@ -1,7 +1,8 @@
 var mqtt = require('mqtt');
 var LightMeterWidget = require('lightmeter').Widget;
 
-var lightTopic = 'ciot/pinhole/light/value';
+var id = process.env.ID;
+var lightTopic = 'ciot/pinhole/' + id + '/light/value';
 
 var lightMeter = new LightMeterWidget();
 


### PR DESCRIPTION
For all exercises involving the `ciot/pinhole/#` topic, require the use of a unique ID read from `process.env.ID`.

When verifying the exercises a unique ID is injected for testing. When the participant runs the examples on their own, we remind them (in problem.md) to prepend `ID=<your-id>` to the invocation.
